### PR TITLE
feat: implement commit message regeneration (#1)

### DIFF
--- a/cmd/gmmit/main.go
+++ b/cmd/gmmit/main.go
@@ -8,5 +8,5 @@ func main() {
 
 	LoadEnvironment()
 
-	GenerateCommitMessage()
+	RunCommitGeneration()
 }

--- a/internal/pkg/common/common.go
+++ b/internal/pkg/common/common.go
@@ -62,6 +62,8 @@ func AskConfirmation(message string) (int) {
 	confirmation = strings.ToLower(strings.TrimSpace(confirmation))
 	if confirmation == "y" || confirmation == "yes" {
 		return 1
-	} 
+	} else if confirmation == "r" {
+		return 2
+	}
 	return 0
 }


### PR DESCRIPTION
This commit introduces the functionality to regenerate a commit message if the user is not satisfied with the initial suggestion.

The following changes were made:

- Added a new option to the confirmation prompt, allowing the user to regenerate the commit message.
- Updated the `GenerateCommitMessage` function to handle the new option and call itself recursively if regeneration is requested.
- Modified the `main` function to call `RunCommitGeneration` instead of `GenerateCommitMessage` to initiate the process.