### PR TITLE
feat: Add build script for multiple platforms (#13)

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -o errexit
+
+set -o nounset
+set -o pipefail
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
+main() {
+    build darwin arm64
+    build darwin amd64
+    build linux 386
+    build linux amd64
+    build windows 386
+    build windows amd64
+}
+
+function build() {
+    OS=$1
+    ARCH=$2
+    echo "[INFO] Building for ${OS} (${ARCH})"
+    env GOOS=${OS} GOARCH=${ARCH} go build -o build/${OS}-${ARCH}/gmmit ./cmd/gmmit/
+    tar -czf build/${OS}-${ARCH}.tgz --directory=build/${OS}-${ARCH} gmmit
+    rm -rf build/${OS}-${ARCH}
+}
+
+main "$@"


### PR DESCRIPTION
This commit introduces a new build script that can build the project for multiple platforms:
- darwin (arm64 and amd64)
- linux (386 and amd64)
- windows (386 and amd64)