### PR TITLE
8 add an option to generate a pr text

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ apk add --update git
 3. Run you code:
 
 ```bash
+echo GMMIT_API_KEY="<API_KEY>" > ~/.gmenv
 go run ./cmd/gmmit/
 ```
 
@@ -108,6 +109,23 @@ This error happen when the AI Model detects the content being sent is potenciall
 Error 429 generally indicates that you have exceeded the limit of allowed requests in a specific time period when interacting with a Google API. 
 
 This can occur when making many requests to an API in a short period of time.
+
+### Pull Request fail - ambiguous argument
+
+```
+fatal: ambiguous argument 'remotes/origin/HEAD': unknown revision or path not in the working tree.
+Use '--' to separate paths from revisions, like this:
+'git <command> [<revision>...] -- [<file>...]'
+```
+
+This is usually due to having `origin/HEAD` missing on your local repo. This ref is generated during clone, if you don't have it, run the following command to make Git set it for you:
+
+```bash
+git remote set-head origin --auto
+```
+
+Run gmmit again.
+
 
 ## Contributing
 

--- a/cmd/gmmit/main.go
+++ b/cmd/gmmit/main.go
@@ -8,11 +8,16 @@ import (
 
 var(
     noVerifyFlag = flag.Bool("no-verify", false, "Runs the 'git commit' command with '--no-verify'.")
+	generatePR = flag.Bool("pr", false, "Generates a PR Message for changes in branch to be merged into default branch.")
 )
 
 func main() {
 	flag.Parse()
 	LoadEnvironment()
 
-	RunCommitGeneration()
+	if *generatePR == true {
+		RunPRGeneration()
+	} else {
+		RunCommitGeneration()
+	}
 }

--- a/cmd/gmmit/prGenerator.go
+++ b/cmd/gmmit/prGenerator.go
@@ -6,14 +6,14 @@ import (
 	"strings"
 	
 	. "gitlab.com/orion-rep/gmmit/internal/pkg/common"
-	//. "gitlab.com/orion-rep/gmmit/internal/pkg/ai"
+	. "gitlab.com/orion-rep/gmmit/internal/pkg/ai"
 )
 
 var prPrompt, gitPRDiff, gitPRBranch string = "","",""
 
 func RunPRGeneration() {
 	Info("Getting context information")
-	gitDiff, gitBranch = GetPRContext()
+	gitPRDiff, gitPRBranch = GetPRContext()
     GeneratePRMessage()
 }
 
@@ -46,12 +46,13 @@ func GeneratePRMessage() {
 		gitPRBranch, gitPRDiff)
 	
 	Debug(prPrompt)
-	//res := RunPRPrompt(prPrompt)
+	res := RunPrompt(prPrompt)
 
-	//PrintModelResponse(res)
+	PrintModelResponse(res)
 
-	switch option := AskConfirmation("Copy this PR Message to your clipboard? [y/N/r]"); option {
-		
+	switch option := AskConfirmation("Do you want to re-generate the PR Message? [y/N]"); option {
+		case 1:
+			GeneratePRMessage()
 		default:
 			os.Exit(0)
 	}

--- a/cmd/gmmit/prGenerator.go
+++ b/cmd/gmmit/prGenerator.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"os"
+	"fmt"
+	"strings"
+	
+	. "gitlab.com/orion-rep/gmmit/internal/pkg/common"
+	//. "gitlab.com/orion-rep/gmmit/internal/pkg/ai"
+)
+
+var prPrompt, gitPRDiff, gitPRBranch string = "","",""
+
+func RunPRGeneration() {
+	Info("Getting context information")
+	gitDiff, gitBranch = GetPRContext()
+    GeneratePRMessage()
+}
+
+
+func GetPRContext()(string, string) {
+	
+	defaultBranch := strings.ReplaceAll(string(RunCommand("git", "rev-parse", "--abbrev-ref", "origin/HEAD")), "\n", "")
+
+	Debug("Checking changes against branch '%s'", defaultBranch)
+	diff := string(RunCommand("git","diff",fmt.Sprintf("%s...", defaultBranch)))
+
+	if len(diff) <= 0 {
+		Warning("Git diff returned no files")
+		Warning("Add some files to the staging area and run this command again")
+		os.Exit(0)
+	}
+	
+	branch := strings.ReplaceAll(string(RunCommand("git", "rev-parse", "--abbrev-ref", "HEAD")), "\n", "")
+
+	return diff, branch
+    
+}
+
+
+func GeneratePRMessage() {
+
+	Info("Generating PR message")
+
+	prPrompt = fmt.Sprintf("Create a Pull Request message with following sections: 'What changed?', 'Why/Context', 'How to test it?'. The Ticket ID MUST be present on the PR title line, look for it on the branch name: \"%s\". Respond with the pr message only. Title line can not be a generic line, must be a specific change. If there are many changes, list the rest at the end. These are the changes to be merged:\n%s",
+		gitPRBranch, gitPRDiff)
+	
+	Debug(prPrompt)
+	//res := RunPRPrompt(prPrompt)
+
+	//PrintModelResponse(res)
+
+	switch option := AskConfirmation("Copy this PR Message to your clipboard? [y/N/r]"); option {
+		
+		default:
+			os.Exit(0)
+	}
+}


### PR DESCRIPTION
### What changed?

- Added a new flag `-pr` to the `gmmit` command.
- When executed with the `-pr` flag, the tool will analyze the diff between the current branch and the default branch and generate a PR message suggestion.
- Updated documentation with new flag usage.

### Why/Context

This change automates the process of writing a PR message, saving developers time and effort.

### How to test it?

1. Create a new branch and introduce some changes.
2. Run `gmmit -pr`.
3. The tool will print a PR message suggestion to the terminal.
4. Verify that the message accurately reflects the changes you made.