### PR TITLE
feat(clipboard): add option to copy generated text to clip board (#9)

### DIFF
--- a/cmd/gmmit/commitGenerator.go
+++ b/cmd/gmmit/commitGenerator.go
@@ -33,6 +33,7 @@ func GenerateCommitMessage() {
 	switch option := AskConfirmation("Create a commit with this message? [y/N/r]"); option {
 		case 1:
 			CreateCommit(ModelResponseToString(res))
+			Info("Commit created, remember to run 'git push'.")
 		case 2:
 			GenerateCommitMessage()
 		default:

--- a/cmd/gmmit/prGenerator.go
+++ b/cmd/gmmit/prGenerator.go
@@ -18,7 +18,6 @@ func RunPRGeneration() {
     GeneratePRMessage()
 }
 
-
 func GetPRContext()(string, string) {
 	
 	defaultBranch := strings.ReplaceAll(string(RunCommand("git", "rev-parse", "--abbrev-ref", "origin/HEAD")), "\n", "")
@@ -38,12 +37,11 @@ func GetPRContext()(string, string) {
     
 }
 
-
 func GeneratePRMessage() {
 
 	Info("Generating PR message")
 
-	prPrompt = fmt.Sprintf("Create a Pull Request message with following sections: 'What changed?', 'Why/Context', 'How to test it?'. The Ticket ID MUST be present on the PR title line, look for it on the branch name: \"%s\". Respond with the pr message only. Title line can not be a generic line, must be a specific change. If there are many changes, list the rest at the end. These are the changes to be merged:\n%s",
+	prPrompt = fmt.Sprintf("Create a Pull Request message with following sections: 'What changed?', 'Why/Context', 'How to test it?'. The title line should follow the 'Conventional Commits' standard. The Ticket ID MUST be present on the PR title line, look for it on the branch name: \"%s\". Respond with the pr message only. Title line can not be a generic line, must be a specific change. If there are many changes, list the rest at the end. These are the changes to be merged:\n%s",
 		gitPRBranch, gitPRDiff)
 	
 	Debug(prPrompt)

--- a/cmd/gmmit/prGenerator.go
+++ b/cmd/gmmit/prGenerator.go
@@ -7,6 +7,7 @@ import (
 	
 	. "gitlab.com/orion-rep/gmmit/internal/pkg/common"
 	. "gitlab.com/orion-rep/gmmit/internal/pkg/ai"
+	"github.com/atotto/clipboard"
 )
 
 var prPrompt, gitPRDiff, gitPRBranch string = "","",""
@@ -50,8 +51,11 @@ func GeneratePRMessage() {
 
 	PrintModelResponse(res)
 
-	switch option := AskConfirmation("Do you want to re-generate the PR Message? [y/N]"); option {
+	switch option := AskConfirmation("Copy this PR Message to your clipboard? [y/N/r]"); option {
 		case 1:
+			clipboard.WriteAll(ModelResponseToString(res))
+			Info("PR Message copied! You're good to go.")
+		case 2:
 			GeneratePRMessage()
 		default:
 			os.Exit(0)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.2 // indirect
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	cloud.google.com/go/longrunning v0.5.7 // indirect
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1h
 cloud.google.com/go/longrunning v0.5.7 h1:WLbHekDbjK1fVFD3ibpFFVoyizlLRl73I7YKuAKilhU=
 cloud.google.com/go/longrunning v0.5.7/go.mod h1:8GClkudohy1Fxm3owmBGid8W0pSgodEMwEAztp38Xng=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=


### PR DESCRIPTION
## What changed?

This PR introduces a new feature that allows users to copy the generated PR message to their clipboard. 

**Specific Changes:**

- Added the option to copy generated PR messages to the clipboard.
- Added a confirmation message after copying to the clipboard.
- Added the `github.com/atotto/clipboard` package to handle clipboard operations.
- Updated the commit generator to remind users to push their commits.

## Why/Context

This feature improves the user experience by making it easier to use the generated PR message. It eliminates the need to manually copy and paste the message, saving time and effort.

## How to test it?

1. Run the PR message generator.
2. Choose the option to copy the message to your clipboard.
3. Paste the clipboard contents into a text editor to confirm that the PR message was copied successfully. 

