### PR TITLE
10 add option to create the pr with generated text

### DIFF
--- a/cmd/gmmit/commitGenerator.go
+++ b/cmd/gmmit/commitGenerator.go
@@ -36,7 +36,7 @@ func GenerateCommitMessage() {
 	PrintModelResponse(res)
 	Info("---")
 
-	switch option := AskConfirmation("Create a commit with this message? [y/N/r]"); option {
+	switch option := AskConfirmation("Create a commit with this message? or Regenerate the text(r)? [y/N/r]"); option {
 		case 1:
 			CreateCommit(ModelResponseToString(res))
 			Info("Commit created, remember to run 'git push'.")

--- a/cmd/gmmit/commitGenerator.go
+++ b/cmd/gmmit/commitGenerator.go
@@ -18,12 +18,15 @@ func RunCommitGeneration() {
 	GenerateCommitMessage()
 }
 
+func generatePrompt(commitStandard, gitBranch, gitDiff string) string {
+    return fmt.Sprintf("Create a git commit message following the \"Conventional Commits\" standard: \"%s\". The Ticket ID MUST be present on the first line, look for it on the branch name: \"%s\". Respond with the commit message only. First line can not be a generic line, must be a specific change. If there are many changes, list the rest at the end. These are the file changes to be pushed:\n%s", commitStandard, gitBranch, gitDiff)
+}
+
 func GenerateCommitMessage() {
 
 	Info("Generating commit message")
 
-	prompt = fmt.Sprintf("Create a git commit message following the \"Conventional Commits\" standard: \"%s\". The Ticket ID MUST be present on the first line, look for it on the branch name: \"%s\". Respond with the commit message only. First line can not be a generic line, must be a specific change. If there are many changes, list the rest at the end. These are the file changes to be pushed:\n%s",
-				commitStandard, gitBranch, gitDiff)
+	prompt = generatePrompt(commitStandard, gitBranch, gitDiff)
 	
 	Debug(prompt)
 	res := RunPrompt(prompt)

--- a/cmd/gmmit/commitGenerator.go
+++ b/cmd/gmmit/commitGenerator.go
@@ -31,7 +31,10 @@ func GenerateCommitMessage() {
 	Debug(prompt)
 	res := RunPrompt(prompt)
 
+	Info("Generated Text:")
+	Info("---")
 	PrintModelResponse(res)
+	Info("---")
 
 	switch option := AskConfirmation("Create a commit with this message? [y/N/r]"); option {
 		case 1:
@@ -61,7 +64,7 @@ func GetCommitContext()(string, string) {
 }
 
 func CreateCommit(msg string) {
-	Info("Creating Commit...")
+	Info("Creating Commit")
 	gitOptions := [] string { "commit" }
 	if *noVerifyFlag == true {
 		Debug("Adding '--no-verify' option to git commit")

--- a/cmd/gmmit/commitGenerator.go
+++ b/cmd/gmmit/commitGenerator.go
@@ -31,8 +31,8 @@ func GenerateCommitMessage() {
 	Debug(prompt)
 	res := RunPrompt(prompt)
 
-	Info("Generated Text:")
-	Info("---")
+	Info("Text Generated")
+	Info("Commit Message:")
 	PrintModelResponse(res)
 	Info("---")
 

--- a/cmd/gmmit/prGenerator.go
+++ b/cmd/gmmit/prGenerator.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"fmt"
+	"encoding/json"
 	"strings"
 	
 	. "gitlab.com/orion-rep/gmmit/internal/pkg/common"
@@ -41,21 +42,67 @@ func GeneratePRMessage() {
 
 	Info("Generating PR message")
 
-	prPrompt = fmt.Sprintf("Create a Pull Request message with following sections: 'What changed?', 'Why/Context', 'How to test it?'. The title line should follow the 'Conventional Commits' standard. The Ticket ID MUST be present on the PR title line, look for it on the branch name: \"%s\". Respond with the pr message only. Title line can not be a generic line, must be a specific change. If there are many changes, list the rest at the end. These are the changes to be merged:\n%s",
+	prPrompt = fmt.Sprintf("Create a Pull Request message with following sections: 'What changed?', 'Why/Context', 'How to test it?'. The title line should follow the 'Conventional Commits' standard. The Ticket ID MUST be present on the PR title line, look for it on the branch name: \"%s\". Respond with the pr message only. Title line can not be a generic line, must be a specific change. If there are many changes, list the rest at the end. Answer must be a valid json with no '`' characters, following this template: {title:'',description:''}.These are the changes to be merged:\n%s",
 		gitPRBranch, gitPRDiff)
 	
 	Debug(prPrompt)
 	res := RunPrompt(prPrompt)
 
-	PrintModelResponse(res)
+	Debug("Model Response:\n%s",ModelResponseToString(res))
+
+	var response map[string]string
+	err := json.Unmarshal([]byte(ModelResponseToString(res)), &response)
+	prTitle := response["title"]
+	prDescription := response["description"]
+	CheckIfError(err)
+
+	Info("PR Title:")
+	fmt.Println(prTitle)
+	Info("PR Description:")
+	fmt.Println(prDescription)
 
 	switch option := AskConfirmation("Copy this PR Message to your clipboard? [y/N/r]"); option {
 		case 1:
 			clipboard.WriteAll(ModelResponseToString(res))
 			Info("PR Message copied! You're good to go.")
+			createPRBitbucket(prTitle,gitPRBranch, prDescription, "flashtalking/ft-dns")
 		case 2:
 			GeneratePRMessage()
 		default:
 			os.Exit(0)
 	}
+}
+
+func createPRBitbucket(title string, sourceBranch string, message string, repo string) {
+	
+	url := "https://api.bitbucket.org/2.0/repositories/" + repo + "/pullrequests"
+	
+	payload := map[string]interface{}{
+		"title":title, 
+		"source": map[string]interface{}{
+			"branch": map[string]string{
+				"name": sourceBranch,
+			},
+		},
+		"description": message,
+	}
+	
+	resp, status, err := CallPost(url, payload ,GetEnvArg("GMMIT_BB_USER"), GetEnvArg("GMMIT_BB_PASS"))
+	CheckIfError(err)
+
+	response, err := ResponseParser(resp)
+	CheckIfError(err)
+	Debug("Response: %s", response)
+
+	if status != 201 {
+		Error("PR creation failed with the following error message:")
+		errorResp := response["error"].(map[string]interface{})
+		Error(fmt.Sprint(errorResp["message"]))
+		os.Exit(1)
+	}
+
+	newPRURL := fmt.Sprint(response["links"].(map[string]interface{})["html"].(map[string]interface{})["href"])
+	Info("PR URL: %s", newPRURL)
+
+	OpenURL(newPRURL)
 }

--- a/cmd/gmmit/prGenerator.go
+++ b/cmd/gmmit/prGenerator.go
@@ -109,7 +109,7 @@ func createPRBitbucket(title string, sourceBranch string, message string, repo s
 	resp, status, err := CallPost(url, payload ,GetEnvArg("GMMIT_BB_USER"), GetEnvArg("GMMIT_BB_PASS"))
 	CheckIfError(err)
 
-	response, err := ResponseParser(resp)
+	response, err := ResponseJsonParser(resp)
 	CheckIfError(err)
 	Debug("Response: %s", response)
 

--- a/docs/git-tokens.md
+++ b/docs/git-tokens.md
@@ -1,0 +1,34 @@
+# Git Authentication Tokens
+
+## BitBucket
+
+1. Login into your bickbucket account
+
+2. Go to **Personal Settings** (Click the cog icon at the upper right corner).
+
+3. Go to **ACCESS MANAGEMENT > App Password** on the left side menu.
+
+4. Click on **Create app password**.
+
+5. Add a label for the new password, and set the following permissions:
+
+| Permission | Type |
+| ---------- | ---- |
+| Repositories | [x] Read |
+| Repositories | [x] Write |
+| Pull requests | [x] Read |
+| Pull requests | [x] Write |
+
+6. Click **Create**, and make sure to save the generated password on a safe place.
+
+7. To generate the personal access token simply encode the string "<username>:<app_password>" using base64.
+
+    i.e.
+
+    ```bash
+    echo 'luke-skywalker:fdJS()FJd8s9FJ8d9WZ0OkFUQkJERmN0tR34LRlzbjRXN1U2YlhlQTdOOUwzMDU4NEY0MAo=' | base64
+    ```
+
+    You should get something like: `bHVrZS1za3l3YWxrZXI6ZmRKUygpRkpkOHM5Rko4ZDlXWjBPa0ZVUWtKRVJtTjB0UjM0TFJsemJqUlhOMVUyWWxobFFUZE9PVXd6TURVNE5FWTBNQW89Cg==`
+
+Check the official [BitBucket Docs](https://support.atlassian.com/bitbucket-cloud/docs/create-an-app-password/) for more details.

--- a/internal/pkg/ai/gemini.go
+++ b/internal/pkg/ai/gemini.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
+	"strings"
+	"strconv"
 	
 	"github.com/google/generative-ai-go/genai"
 	"google.golang.org/api/option"
@@ -33,16 +36,54 @@ func RunPrompt(prompt string) (*genai.GenerateContentResponse) {
 	return res
 }
 
+// SendMessageToModel sends a message to the specified GenerativeModel and returns the response.
+// It retries the SendMessage call up to maxRetries times if the error is a 500 Internal Server Error,
+// with a delay of retryDelay between each retry attempt.
+//
+// ctx is the context.Context to use for the operation.
+// model is a pointer to the genai.GenerativeModel to use for sending the message.
+// msg is the message to send to the model.
+//
+// Returns a pointer to the genai.GenerateContentResponse containing the model's response.
+// If an error occurs and cannot be retried, it logs the error using log.Fatal and exits the program.
 func SendMessageToModel(ctx context.Context, model *genai.GenerativeModel, msg string) *genai.GenerateContentResponse {
-	Debug("Starting GenAI Chat")
-	cs := model.StartChat()
-	Debug("Sending GenAI Message")
-	res, err := cs.SendMessage(ctx, genai.Text(msg))
-	if err != nil {
-		log.Fatal(err)
-	}
-	return res
+    Debug("Starting GenAI Chat")
+    cs := model.StartChat()
+    Debug("Sending GenAI Message")
+
+    var res *genai.GenerateContentResponse
+    var err error
+    maxRetries, err := strconv.Atoi(GetEnvArg("GMMIT_MAX_RETRIES", "5"))
+	CheckIfError(err)
+    retryDelay, err := strconv.Atoi(GetEnvArg("GMMIT_RETRY_DELAY", "5"))
+	CheckIfError(err)
+
+	retryDelayDuration := time.Duration(retryDelay) * time.Second
+
+    for i := 0; i < maxRetries; i++ {
+        res, err = cs.SendMessage(ctx, genai.Text(msg))
+        if err == nil {
+            break
+        }
+
+        // Check if the error is a 500 Internal Server Error
+        if strings.Contains(err.Error(), "500") {
+            Debug(fmt.Sprintf("Received 500 error, retrying in %v (attempt %d/%d)", retryDelayDuration, i+1, maxRetries))
+            time.Sleep(retryDelayDuration)
+            continue
+        }
+
+        // For other errors, break the loop
+        log.Fatal(err)
+    }
+
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    return res
 }
+
 
 func ModelResponseToString(resp *genai.GenerateContentResponse)(string){
 	stringResponse := ""

--- a/internal/pkg/ai/gemini.go
+++ b/internal/pkg/ai/gemini.go
@@ -98,8 +98,6 @@ func ModelResponseToString(resp *genai.GenerateContentResponse)(string){
 }
 
 func PrintModelResponse(resp *genai.GenerateContentResponse) {
-	Info("Generated Text:")
-	Info("---")
 	for _, cand := range resp.Candidates {
 		if cand.Content != nil {
 			for _, part := range cand.Content.Parts {
@@ -107,5 +105,4 @@ func PrintModelResponse(resp *genai.GenerateContentResponse) {
 			}
 		}
 	}
-	Info("---")
 }

--- a/internal/pkg/common/common.go
+++ b/internal/pkg/common/common.go
@@ -6,24 +6,40 @@ import (
 	"os/exec"
 	"strings"
 	"bytes"
+	"runtime"
 )
 
+// RunCommand executes a command-line command with the provided parameters
+// and returns the output of the command as a string.
 func RunCommand(command string, params ...string) (string) {
-	Debug("Running command: \"%s\", with params: %s",command, params)
-	cmd := exec.Command(command, params...)
-	
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
-	
-	err := cmd.Run()
-	Debug("Command output: %s", out.String())
+    // Log the command and parameters being executed
+    Debug("Running command: \"%s\", with params: %s", command, params)
+
+    // Create a new command object with the provided command and parameters
+    cmd := exec.Command(command, params...)
+
+    // Create buffers to store the standard output and standard error
+    var out bytes.Buffer
+    var stderr bytes.Buffer
+
+    // Assign the buffers to the command's output and error streams
+    cmd.Stdout = &out
+    cmd.Stderr = &stderr
+
+    // Execute the command
+    err := cmd.Run()
+
+    // Log the command output
+    Debug("Command output: %s", out.String())
+
+    // Check if an error occurred during the command execution
+    // and handle it accordingly
     CheckIfError(err, stderr.String())
-	
-	return out.String()
+
+    // Return the command output as a string
+    return out.String()
 }
+
 
 // CheckArgs should be used to ensure the right command line arguments are
 // passed before executing an example.
@@ -73,4 +89,23 @@ func CommandExists(cmd string) {
 		Warning("%s could not be found. Install it and run this command again.", cmd)
 	} 
 	CheckIfError(err)
+}
+
+// https://stackoverflow.com/questions/39320371/how-start-web-server-to-open-page-in-browser-in-golang
+// open opens the specified URL in the default browser of the user.
+func OpenURL(url string) error {
+    var cmd string
+    var args []string
+
+    switch runtime.GOOS {
+    case "windows":
+        cmd = "cmd"
+        args = []string{"/c", "start"}
+    case "darwin":
+        cmd = "open"
+    default: // "linux", "freebsd", "openbsd", "netbsd"
+        cmd = "xdg-open"
+    }
+    args = append(args, url)
+    return exec.Command(cmd, args...).Start()
 }

--- a/internal/pkg/common/common.go
+++ b/internal/pkg/common/common.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"bytes"
 	"runtime"
-	"errors"
 )
 
 // RunCommand executes a command-line command with the provided parameters
@@ -109,15 +108,4 @@ func OpenURL(url string) error {
     }
     args = append(args, url)
     return exec.Command(cmd, args...).Start()
-}
-
-// GetRepoRawName returns the raw name of a repository from its full name
-func GetRepoRawName(repository string) (string, error) {
-    repoGitName := strings.Split(repository, ":")
-    if len(repoGitName) < 2 {
-        return "", errors.New("Invalid repository name. " + repository + " could not be parsed properly")
-    }
-	// Removing '.git' from name
-	repoName := strings.ReplaceAll(repoGitName[1], ".git", "")
-    return repoName, nil
 }

--- a/internal/pkg/common/common.go
+++ b/internal/pkg/common/common.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"bytes"
 	"runtime"
+	"errors"
 )
 
 // RunCommand executes a command-line command with the provided parameters
@@ -108,4 +109,15 @@ func OpenURL(url string) error {
     }
     args = append(args, url)
     return exec.Command(cmd, args...).Start()
+}
+
+// GetRepoRawName returns the raw name of a repository from its full name
+func GetRepoRawName(repository string) (string, error) {
+    repoGitName := strings.Split(repository, ":")
+    if len(repoGitName) < 2 {
+        return "", errors.New("Invalid repository name. " + repository + " could not be parsed properly")
+    }
+	// Removing '.git' from name
+	repoName := strings.ReplaceAll(repoGitName[1], ".git", "")
+    return repoName, nil
 }

--- a/internal/pkg/common/common.go
+++ b/internal/pkg/common/common.go
@@ -6,8 +6,6 @@ import (
 	"os/exec"
 	"strings"
 	"bytes"
-	"log"
-
 )
 
 func RunCommand(command string, params ...string) (string) {
@@ -54,18 +52,18 @@ func AskConfirmation(message string) (int) {
 
 	Question(message)
 
-	reader := bufio.NewReader(os.Stdin)
-	confirmation, err := reader.ReadString('\n')
-		if err != nil {
-			log.Fatal(err)
-		}
-	confirmation = strings.ToLower(strings.TrimSpace(confirmation))
-	if confirmation == "y" || confirmation == "yes" {
-		return 1
-	} else if confirmation == "r" {
-		return 2
-	}
-	return 0
+    scanner := bufio.NewScanner(os.Stdin)
+    scanner.Scan()
+    input := strings.ToLower(strings.TrimSpace(scanner.Text()))
+
+    switch input {
+    case "y", "yes":
+        return 1 //Confirmed
+    case "r":
+        return 2 //Retry
+    default:
+        return 0 //Canceled
+    }
 }
 
 func CommandExists(cmd string) {

--- a/internal/pkg/common/gitHelper.go
+++ b/internal/pkg/common/gitHelper.go
@@ -1,0 +1,17 @@
+package common
+
+import (
+	"strings"
+	"errors"
+)
+
+// GetRepoRawName returns the raw name of a repository from its full name
+func GetRepoRawName(repository string) (string, error) {
+    repoGitName := strings.Split(repository, ":")
+    if len(repoGitName) < 2 {
+        return "", errors.New("Invalid repository name. " + repository + " could not be parsed properly")
+    }
+	// Removing '.git' from name
+	repoName := strings.ReplaceAll(repoGitName[1], ".git", "")
+    return repoName, nil
+}

--- a/internal/pkg/common/gitHelper.go
+++ b/internal/pkg/common/gitHelper.go
@@ -1,12 +1,13 @@
 package common
 
 import (
+    "fmt"
 	"strings"
 	"errors"
 )
 
-// GetRepoRawName returns the raw name of a repository from its full name
-func GetRepoRawName(repository string) (string, error) {
+// getRepoRawName returns the raw name of a repository from its full name
+func getRepoRawName(repository string) (string, error) {
     repoGitName := strings.Split(repository, ":")
     if len(repoGitName) < 2 {
         return "", errors.New("Invalid repository name. " + repository + " could not be parsed properly")
@@ -14,4 +15,30 @@ func GetRepoRawName(repository string) (string, error) {
 	// Removing '.git' from name
 	repoName := strings.ReplaceAll(repoGitName[1], ".git", "")
     return repoName, nil
+}
+
+func GetDefaultBranch() (string){
+    defaultBranch := strings.ReplaceAll(string(RunCommand("git", "rev-parse", "--abbrev-ref", "origin/HEAD")), "\n", "")
+	Debug("Default branch: %s", defaultBranch)
+    return defaultBranch
+}
+
+func GetCurrentBranch() (string){
+    currentBranch := strings.ReplaceAll(string(RunCommand("git", "rev-parse", "--abbrev-ref", "HEAD")), "\n", "")
+	Debug("Current branch: %s", currentBranch)
+    return currentBranch
+}
+
+func GetRepositoryName() (string){
+    remoteRepository := strings.ReplaceAll(string(RunCommand("git", "config", "--get", "remote.origin.url")), "\n", "")
+	repositoryName, err := getRepoRawName(remoteRepository)
+    CheckIfError(err)
+	Debug("Repository name: %s", repositoryName)
+    return repositoryName
+}
+
+func CalculateDiffBetweenBranches(branch1, branch2 string) (string){
+	Debug("Checking changes between branch '%s' and '%s'", branch1, branch2)
+    diff := string(RunCommand("git","diff",fmt.Sprintf("%s...%s", branch1, branch2)))
+	return diff
 }

--- a/internal/pkg/common/gitHelper.go
+++ b/internal/pkg/common/gitHelper.go
@@ -6,15 +6,28 @@ import (
 	"errors"
 )
 
-// getRepoRawName returns the raw name of a repository from its full name
-func getRepoRawName(repository string) (string, error) {
+func parseRepoName(repository string) (string, string, error) {
     repoGitName := strings.Split(repository, ":")
     if len(repoGitName) < 2 {
-        return "", errors.New("Invalid repository name. " + repository + " could not be parsed properly")
+        return "", "", errors.New("Invalid repository name. " + repository + " could not be parsed properly")
     }
 	// Removing '.git' from name
 	repoName := strings.ReplaceAll(repoGitName[1], ".git", "")
-    return repoName, nil
+    Debug("Repository name: %s", repoName)
+
+    repoProvider := "Generic"
+    if strings.Contains(repoGitName[0], "bitbucket") {
+        repoProvider = "Bitbucket"
+    } else if strings.Contains(repoGitName[0], "github") {
+        // repoProvider = "Github" // Not supported yes
+        Debug("Github provider is not supported yes")
+    } else if strings.Contains(repoGitName[0], "gitlab") {
+        // repoProvider = "Gitlab" // Not supported yet
+        Debug("Gitlab provider is not supported yet")
+    }
+    Debug("Repository provider: %s", repoProvider)
+
+    return repoName, repoProvider, nil
 }
 
 func GetDefaultBranch() (string){
@@ -29,12 +42,11 @@ func GetCurrentBranch() (string){
     return currentBranch
 }
 
-func GetRepositoryName() (string){
+func GetRepositoryData() (string, string){
     remoteRepository := strings.ReplaceAll(string(RunCommand("git", "config", "--get", "remote.origin.url")), "\n", "")
-	repositoryName, err := getRepoRawName(remoteRepository)
+	repositoryName, repositoryProvider, err := parseRepoName(remoteRepository)
     CheckIfError(err)
-	Debug("Repository name: %s", repositoryName)
-    return repositoryName
+	return repositoryName, repositoryProvider
 }
 
 func CalculateDiffBetweenBranches(branch1, branch2 string) (string){

--- a/internal/pkg/common/logging.go
+++ b/internal/pkg/common/logging.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-// Info should be used to describe the example commands that are about to run.
+// Debug should be used to display debugging information
 func Debug(format string, args ...interface{}) {
 	debug := GetEnvArg("GMMIT_DEBUG", "false")
 	if debug == "true" {
@@ -15,16 +15,16 @@ func Debug(format string, args ...interface{}) {
 func Info(format string, args ...interface{}) {
 	fmt.Printf("\x1b[34;1m[INFO] %s\x1b[0m\n", fmt.Sprintf(format, args...))
 }
-// Info should be used to describe the example commands that are about to run.
+// Question should be used to display a message that the user will have to interact with.
 func Question(format string, args ...interface{}) {
 	fmt.Printf("\x1b[36;1m[INFO] %s\x1b[0m ", fmt.Sprintf(format, args...))
 }
-// Warning should be used to display a warning
+// Warning should be used to display a message about an unexpected situation
 func Warning(format string, args ...interface{}) {
 	fmt.Printf("\x1b[33;1m[WARN] %s\x1b[0m\n", fmt.Sprintf(format, args...))
 }
 
-// Warning should be used to display a warning
+// Error should be used to display an error that prevents the tool from continuing
 func Error(format string, args ...interface{}) {
 	fmt.Printf("\x1b[31;1m[ERRO] %s\x1b[0m\n", fmt.Sprintf(format, args...))
 }

--- a/internal/pkg/common/rest.go
+++ b/internal/pkg/common/rest.go
@@ -42,7 +42,7 @@ func CallPost(url string, payload interface{}, user string, pass string) ([]byte
 	return body, resp.StatusCode, nil
 }
 
-func ResponseParser(resp []byte) (map[string]any, error) {
+func ResponseJsonParser(resp []byte) (map[string]any, error) {
 	var result map[string]any
 	err := json.Unmarshal(resp, &result)
 	if err != nil {

--- a/internal/pkg/common/rest.go
+++ b/internal/pkg/common/rest.go
@@ -1,0 +1,53 @@
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+)
+
+
+/*
+/ The callPost function makes a REST API POST call.
+/ The first parameter is the URL of the API.
+/ The second parameter is the payload that needs to be sent with the POST request.
+/ The third parameter is the authorization token that needs to be sent along with the request.
+/ The function returns the response body, response status code and any error occurred during the request.
+*/
+func CallPost(url string, payload interface{}, user string, pass string) ([]byte, int, error) {
+	jsonValue, _ := json.Marshal(payload)
+	Debug("HTTP JSON payload:%s", jsonValue)
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonValue))
+    req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(user, pass)
+
+	Debug("Sending POST request to: %s", req.URL.String())
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		Error(err.Error())
+		return nil, 500, err
+	}
+	defer resp.Body.Close()
+
+	Debug("HTTP Status:", resp.Status)
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		Error(err.Error())
+		return nil, resp.StatusCode, err
+	}
+
+	return body, resp.StatusCode, nil
+}
+
+func ResponseParser(resp []byte) (map[string]any, error) {
+	var result map[string]any
+	err := json.Unmarshal(resp, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
### What changed?

Added a new option to the PR generator to automatically create the PR on Bitbucket.

### Why/Context

This feature was added to streamline the PR creation workflow for users using Bitbucket.

### How to test it?

1. Create a new branch and make some changes.
2. Stage your changes.
3. Run `gmmit -pr`.
4. Confirm the PR details and select 'y' to create the PR.
5. Verify that the PR was created successfully on your Bitbucket repository.

### Other changes:

- Introduced error handling and retries for Gemini API calls to enhance resilience against intermittent network issues or server errors.
- Implemented a mechanism to parse repository information from Git configuration to determine the repository provider and name, enabling provider-specific actions like PR creation.
- Enhanced logging and debugging capabilities to improve transparency and facilitate troubleshooting.
- Improved the user experience by providing clearer prompts and instructions during the commit message and PR generation process.
- Updated documentation to guide users on generating Bitbucket app passwords, a prerequisite for using the Bitbucket PR creation feature.