### PR TITLE
feat(57): Implement staging of all files before commit (#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ gmmit --type fix
 Tells the model which Conventional Commit type to use. Accepted values: `feat`, `fix`, `docs`, `style`,
 `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`. An invalid value exits with an error.
 
+### Stage all files
+
+```bash
+gmmit -a
+```
+
+Runs `git add .` before reading the staged diff, so you don't need to stage files manually first.
+Also available as `gmmit --add-all`.
+
 ### Give the AI a hint
 
 ```bash
@@ -112,6 +121,7 @@ message or PR description. Useful when staging a large diff with many unrelated 
 | `--no-verify` | Skip pre-commit hooks when creating the commit |
 | `-y` | Auto-confirm all prompts, run in non-interactive mode |
 | `--type <type>` | Force the commit type (feat, fix, docs, etc.) |
+| `-a` / `--add-all` | Stage all modified files before committing (like `git add .`) |
 | `--hint <text>` | Free-text hint for the AI model about what changes to focus on |
 
 ---

--- a/cmd/gmmit/commitGenerator.go
+++ b/cmd/gmmit/commitGenerator.go
@@ -35,6 +35,10 @@ func RunCommitGeneration() {
 		}
 		commitTypeHint = *commitType
 	}
+	if *addAllFlag || *addAllShortFlag {
+		common.Info("Staging all modified files")
+		common.RunCommand("git", "add", ".")
+	}
 	common.Info("Getting context information")
 	gitDiff, gitBranch = GetCommitContext()
 	commitStandard = common.GetEnvArg("GMMIT_COMMIT_PATTERN", "<type>[optional scope]: <description> (#<ticket-id>)")

--- a/cmd/gmmit/commit_generator_test.go
+++ b/cmd/gmmit/commit_generator_test.go
@@ -241,6 +241,64 @@ func TestGenerateCommitMessage_WithPush(t *testing.T) {
 	captureStdout(func() { GenerateCommitMessage() })
 }
 
+func testRunCommitGenerationAddAll(t *testing.T, setFlag func(), resetFlag func()) {
+	t.Helper()
+	var capturedArgs [][]string
+	callCount := 0
+	common.ExecCommand = func(name string, args ...string) *exec.Cmd {
+		callCount++
+		capturedArgs = append(capturedArgs, append([]string{name}, args...))
+		switch callCount {
+		case 1: // git add .
+			return exec.Command("true")
+		case 2: // git diff --staged
+			return exec.Command("echo", "staged diff content")
+		case 3: // git rev-parse
+			return exec.Command("echo", "feature/123")
+		default: // git commit
+			return exec.Command("echo", "1 file changed")
+		}
+	}
+	defer func() { common.ExecCommand = exec.Command }()
+
+	setFlag()
+	defer resetFlag()
+
+	runPromptFn = func(p string) *genai.GenerateContentResponse {
+		return makeResponse("feat: test commit message")
+	}
+	defer func() { runPromptFn = gemini.RunPrompt }()
+
+	common.StdinReader = strings.NewReader("y\n")
+	defer func() { common.StdinReader = os.Stdin }()
+
+	defer func() { common.LocalEnv = nil }()
+
+	f := false
+	noVerifyFlag = &f
+
+	captureStdout(RunCommitGeneration)
+
+	assert.GreaterOrEqual(t, len(capturedArgs), 1)
+	assert.Equal(t, []string{"git", "add", "."}, capturedArgs[0])
+}
+
+func TestRunCommitGeneration_AddAll(t *testing.T) {
+	tr := true
+	testRunCommitGenerationAddAll(t,
+		func() { addAllFlag = &tr },
+		func() { f := false; addAllFlag = &f },
+	)
+}
+
+func TestRunCommitGeneration_AddAllShort(t *testing.T) {
+	tr := true
+	testRunCommitGenerationAddAll(t,
+		func() { addAllShortFlag = &tr },
+		func() { f := false; addAllShortFlag = &f },
+	)
+}
+
 func TestRunCommitGeneration(t *testing.T) {
 	callCount := 0
 	common.ExecCommand = func(name string, args ...string) *exec.Cmd {

--- a/cmd/gmmit/main.go
+++ b/cmd/gmmit/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 
 	"gitlab.com/orion-rep/gmmit/internal/pkg/common"
 )
@@ -10,13 +11,35 @@ import (
 var (
 	Version string = "[unknown]"
 
-	noVerifyFlag  = flag.Bool("no-verify", false, "Runs the 'git commit' command with '--no-verify'.")
-	generatePR    = flag.Bool("pr", false, "Generates a PR Message for changes in branch to be merged into default branch.")
-	runCommitPush = flag.Bool("pu", false, "Runs 'git push' after creating the commit.")
-	autoConfirm   = flag.Bool("y", false, "Auto-confirm all prompts, run in non-interactive mode.")
-	commitType    = flag.String("type", "", "Force the commit type (feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert).")
-	hintFlag      = flag.String("hint", "", "Free-text hint for the AI model about what changes to focus on.")
+	noVerifyFlag    = flag.Bool("no-verify", false, "Runs the 'git commit' command with '--no-verify'.")
+	generatePR      = flag.Bool("pr", false, "Generates a PR Message for changes in branch to be merged into default branch.")
+	runCommitPush   = flag.Bool("pu", false, "Runs 'git push' after creating the commit.")
+	autoConfirm     = flag.Bool("y", false, "Auto-confirm all prompts, run in non-interactive mode.")
+	commitType      = flag.String("type", "", "Force the commit type (feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert).")
+	hintFlag        = flag.String("hint", "", "Free-text hint for the AI model about what changes to focus on.")
+	addAllFlag      = flag.Bool("add-all", false, "Stage all modified files before committing (like 'git add .').")
+	addAllShortFlag = flag.Bool("a", false, "Stage all modified files before committing (like 'git add .').")
 )
+
+func init() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: gmmit [options]\n\nOptions:\n")
+		flag.VisitAll(func(f *flag.Flag) {
+			if f.Name == "a" {
+				return // shown together with --add-all
+			}
+			var prefix string
+			if f.Name == "add-all" {
+				prefix = "-a, --add-all"
+			} else if len(f.Name) == 1 {
+				prefix = "-" + f.Name
+			} else {
+				prefix = "--" + f.Name
+			}
+			fmt.Fprintf(os.Stderr, "  %-20s%s\n", prefix, f.Usage)
+		})
+	}
+}
 
 func PrintHeader() {
 	fmt.Println(" ╔════════════════════════════════════════════════════════════════════════════════════════╗")


### PR DESCRIPTION
This commit introduces a new functionality to the `gmmit` tool that allows users to automatically stage all modified files before generating a commit message. This is achieved by adding two new flags: `--add-all` and its shorthand `-a`.

When either of these flags is used, the `gmmit` tool will execute `git add .` before proceeding with the commit message generation process. This streamlines the workflow for users, especially when dealing with multiple staged or unstaged changes, by eliminating the need for manual staging.

The changes include:
- Added the `addAllFlag` and `addAllShortFlag` to `cmd/gmmit/main.go` to handle the new command-line options.
- Modified `cmd/gmmit/commitGenerator.go` to check for these flags and execute `git add .` if they are present.
- Updated the `README.md` file to document the new `--add-all` and `-a` flags, providing usage examples and descriptions.
- Added new unit tests in `cmd/gmmit/commit_generator_test.go` to verify the functionality of the `--add-all` and `-a` flags.