### PR TITLE
fix: Remove redundant CHANGELOG update from CI workflow (#release-cha…

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -82,16 +82,6 @@ jobs:
         REPO=${{ github.repository }} \
         bash scripts/changelog.sh > /tmp/release_notes.md
 
-    - name: Update CHANGELOG.md
-      run: |
-        cat /tmp/release_notes.md CHANGELOG.md > /tmp/full_changelog.md
-        mv /tmp/full_changelog.md CHANGELOG.md
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        git add CHANGELOG.md
-        git commit -m "docs: update CHANGELOG for ${GITHUB_REF_NAME} [skip ci]"
-        git push origin HEAD:main
-
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:


### PR DESCRIPTION
…ngelog)

The previous CHANGELOG update logic has been removed from the CI workflow. This was previously responsible for concatenating generated release notes with the existing CHANGELOG and committing it back to the main branch.

This change simplifies the CI process by decoupling the release note generation from the actual CHANGELOG file update, allowing for a more controlled and intentional update process of the CHANGELOG.