### PR TITLE
feat(61): Configure GitHub Pages deployment for project site (#61)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -39,6 +39,29 @@ jobs:
     - name: Build
       run: make build
 
+  pages:
+    needs: [test]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Assemble site
+      run: |
+        mkdir -p _site/images
+        cp site/index.html _site/index.html
+        cp site/CNAME _site/CNAME
+        cp scripts/install.sh _site/install.sh
+        cp images/commit.gif _site/images/commit.gif
+
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./_site
+
   release:
     needs: [test]
     if: startsWith(github.ref, 'refs/tags/v')

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A CLI tool that uses Google Gemini AI to generate [Conventional Commits](https:/
 ### Linux and macOS
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/orion-rep/gmmit/main/scripts/install.sh | bash
+curl -fsSL https://gmmit.orion.net.ar/install.sh | bash
 ```
 
 The script detects your OS and architecture, downloads the latest release binary, and installs it to `/usr/local/bin`.

--- a/site/CNAME
+++ b/site/CNAME
@@ -1,0 +1,1 @@
+gmmit.orion.net.ar

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,376 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>gmmit — AI-powered git commits</title>
+    <meta name="description" content="gmmit reads your staged diff and branch name, calls Google Gemini AI, and delivers a Conventional Commits-ready message — with the right type, scope, and ticket ID.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;800&family=IBM+Plex+Sans:wght@300;400&display=swap" rel="stylesheet">
+    <style>
+        *, *::before, *::after {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        :root {
+            --bg:           #080c0e;
+            --bg-surface:   #0d1416;
+            --bg-terminal:  #090d10;
+            --green:        #00e87a;
+            --green-dim:    #009e54;
+            --green-glow:   rgba(0, 232, 122, 0.10);
+            --text:         #b8cdd1;
+            --text-dim:     #526872;
+            --text-bright:  #ecf4f6;
+            --border:       rgba(0, 232, 122, 0.18);
+            --border-dim:   rgba(255, 255, 255, 0.07);
+            --font-mono:    'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+            --font-sans:    'IBM Plex Sans', -apple-system, sans-serif;
+        }
+
+        html { scroll-behavior: smooth; }
+
+        body {
+            background-color: var(--bg);
+            color: var(--text);
+            font-family: var(--font-sans);
+            font-weight: 300;
+            line-height: 1.75;
+            min-height: 100vh;
+            overflow-x: hidden;
+        }
+
+        /* Scanline overlay */
+        body::before {
+            content: '';
+            position: fixed;
+            inset: 0;
+            background: repeating-linear-gradient(
+                0deg,
+                transparent,
+                transparent 2px,
+                rgba(0, 0, 0, 0.025) 2px,
+                rgba(0, 0, 0, 0.025) 4px
+            );
+            pointer-events: none;
+            z-index: 900;
+        }
+
+        .container {
+            max-width: 820px;
+            margin: 0 auto;
+            padding: 0 2rem;
+        }
+
+        /* ── HERO ─────────────────────────────── */
+        .hero {
+            padding: 11vh 0 7vh;
+            animation: fadeUp 0.7s cubic-bezier(0.22, 1, 0.36, 1) both;
+        }
+
+        .eyebrow {
+            font-family: var(--font-mono);
+            font-size: 0.72rem;
+            letter-spacing: 0.22em;
+            color: var(--green);
+            text-transform: uppercase;
+            margin-bottom: 1.8rem;
+            opacity: 0.75;
+        }
+
+        .eyebrow::before {
+            content: '> ';
+            opacity: 0.45;
+        }
+
+        h1 {
+            font-family: var(--font-mono);
+            font-size: clamp(4rem, 13vw, 7.5rem);
+            font-weight: 800;
+            letter-spacing: -0.045em;
+            color: var(--text-bright);
+            line-height: 1;
+            margin-bottom: 0.6rem;
+        }
+
+        .cursor {
+            display: inline-block;
+            width: 0.075em;
+            height: 0.82em;
+            background: var(--green);
+            margin-left: 0.06em;
+            vertical-align: text-bottom;
+            animation: blink 1.1s step-end infinite;
+        }
+
+        .tagline {
+            font-family: var(--font-mono);
+            font-size: clamp(0.88rem, 2.2vw, 1.1rem);
+            color: var(--green);
+            font-weight: 400;
+            margin-bottom: 2rem;
+            opacity: 0.82;
+        }
+
+        .description {
+            font-size: clamp(0.95rem, 1.8vw, 1.08rem);
+            color: var(--text);
+            max-width: 540px;
+            font-weight: 300;
+            line-height: 1.85;
+        }
+
+        /* ── DEMO ─────────────────────────────── */
+        .demo {
+            padding: 5vh 0 6vh;
+            animation: fadeUp 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.15s both;
+        }
+
+        .terminal-window {
+            background: var(--bg-terminal);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            overflow: hidden;
+            box-shadow:
+                0 0 0 1px rgba(0, 232, 122, 0.04),
+                0 40px 80px rgba(0, 0, 0, 0.55),
+                0 0 100px rgba(0, 232, 122, 0.035);
+        }
+
+        .terminal-bar {
+            background: #0f1518;
+            padding: 0.7rem 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.45rem;
+            border-bottom: 1px solid var(--border-dim);
+        }
+
+        .dot {
+            width: 11px;
+            height: 11px;
+            border-radius: 50%;
+            flex-shrink: 0;
+        }
+
+        .dot-r { background: #ff5f57; }
+        .dot-y { background: #febc2e; }
+        .dot-g { background: #28c840; }
+
+        .terminal-name {
+            flex: 1;
+            text-align: center;
+            font-family: var(--font-mono);
+            font-size: 0.68rem;
+            color: var(--text-dim);
+            letter-spacing: 0.05em;
+        }
+
+        .terminal-window img {
+            width: 100%;
+            height: auto;
+            display: block;
+        }
+
+        /* ── INSTALL ──────────────────────────── */
+        .install {
+            padding: 5vh 0 3vh;
+            animation: fadeUp 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.3s both;
+        }
+
+        h2 {
+            font-family: var(--font-mono);
+            font-size: clamp(1rem, 2.8vw, 1.35rem);
+            font-weight: 600;
+            color: var(--text-bright);
+            margin-bottom: 1.25rem;
+            letter-spacing: -0.02em;
+        }
+
+        h2 .slash {
+            color: var(--green);
+            margin-right: 0.4em;
+            font-weight: 400;
+        }
+
+        .install-block {
+            background: var(--bg-surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 1.1rem 1.4rem;
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            box-shadow: 0 0 40px var(--green-glow);
+        }
+
+        .install-code {
+            font-family: var(--font-mono);
+            font-size: clamp(0.76rem, 1.8vw, 0.9rem);
+            color: var(--text-bright);
+            flex: 1;
+            word-break: break-all;
+        }
+
+        .install-code .prompt {
+            color: var(--green);
+            user-select: none;
+            margin-right: 0.55em;
+        }
+
+        .copy-btn {
+            background: transparent;
+            border: 1px solid rgba(0, 232, 122, 0.3);
+            color: var(--green);
+            font-family: var(--font-mono);
+            font-size: 0.65rem;
+            letter-spacing: 0.12em;
+            padding: 0.3rem 0.75rem;
+            border-radius: 4px;
+            cursor: pointer;
+            transition: background 0.15s, border-color 0.15s;
+            white-space: nowrap;
+            flex-shrink: 0;
+            text-transform: uppercase;
+        }
+
+        .copy-btn:hover {
+            background: rgba(0, 232, 122, 0.1);
+            border-color: var(--green);
+        }
+
+        .copy-btn.copied {
+            background: rgba(0, 232, 122, 0.14);
+            border-color: var(--green);
+        }
+
+        .install-note {
+            margin-top: 0.9rem;
+            font-size: 0.8rem;
+            color: var(--text-dim);
+            font-family: var(--font-mono);
+        }
+
+        /* ── FOOTER ───────────────────────────── */
+        .divider {
+            border: none;
+            border-top: 1px solid var(--border-dim);
+            margin: 5vh 0 3vh;
+        }
+
+        footer {
+            padding-bottom: 7vh;
+            animation: fadeUp 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s both;
+        }
+
+        .gh-link {
+            font-family: var(--font-mono);
+            font-size: 0.88rem;
+            color: var(--text-dim);
+            text-decoration: none;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.45rem;
+            letter-spacing: 0.01em;
+            transition: color 0.15s;
+        }
+
+        .gh-link:hover { color: var(--green); }
+
+        .gh-link .arrow {
+            display: inline-block;
+            transition: transform 0.2s cubic-bezier(0.22, 1, 0.36, 1);
+        }
+
+        .gh-link:hover .arrow { transform: translateX(5px); }
+
+        /* ── ANIMATIONS ───────────────────────── */
+        @keyframes fadeUp {
+            from { opacity: 0; transform: translateY(22px); }
+            to   { opacity: 1; transform: translateY(0); }
+        }
+
+        @keyframes blink {
+            0%, 100% { opacity: 1; }
+            50%       { opacity: 0; }
+        }
+
+        /* ── RESPONSIVE ───────────────────────── */
+        @media (max-width: 560px) {
+            .install-block {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+            .copy-btn { align-self: flex-end; }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+
+        <section class="hero">
+            <p class="eyebrow">git commit, automated</p>
+            <h1>gmmit<span class="cursor"></span></h1>
+            <p class="tagline">AI-powered git commit messages, in seconds.</p>
+            <p class="description">
+                Stop writing commit messages by hand.
+                gmmit reads your staged diff and branch name, calls Google Gemini AI,
+                and delivers a Conventional Commits-ready message —
+                with the right type, scope, and ticket ID.
+            </p>
+        </section>
+
+        <section class="demo">
+            <div class="terminal-window">
+                <div class="terminal-bar">
+                    <span class="dot dot-r"></span>
+                    <span class="dot dot-y"></span>
+                    <span class="dot dot-g"></span>
+                    <span class="terminal-name">zsh — gmmit</span>
+                </div>
+                <img src="images/commit.gif" alt="gmmit in action — generating a Conventional Commits message from staged changes">
+            </div>
+        </section>
+
+        <section class="install">
+            <h2><span class="slash">//</span>Get started in one line</h2>
+            <div class="install-block">
+                <code class="install-code">
+                    <span class="prompt">$</span>curl -fsSL https://gmmit.orion.net.ar/install.sh | bash
+                </code>
+                <button class="copy-btn" onclick="copyInstall(this)" aria-label="Copy install command">
+                    Copy
+                </button>
+            </div>
+            <p class="install-note">
+                Requires a free Google Gemini API key. On first run, gmmit will ask you for it.
+            </p>
+        </section>
+
+        <hr class="divider">
+
+        <footer>
+            <a class="gh-link" href="https://github.com/orion-rep/gmmit">
+                View full documentation on GitHub <span class="arrow">→</span>
+            </a>
+        </footer>
+
+    </div>
+    <script>
+        function copyInstall(btn) {
+            navigator.clipboard.writeText('curl -fsSL https://gmmit.orion.net.ar/install.sh | bash').then(() => {
+                const prev = btn.textContent.trim();
+                btn.textContent = 'Copied!';
+                btn.classList.add('copied');
+                setTimeout(() => {
+                    btn.textContent = prev;
+                    btn.classList.remove('copied');
+                }, 2000);
+            });
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Introduce a new GitHub Actions workflow job `pages` to build and deploy the project's static site to GitHub Pages. This includes steps to assemble the site content (HTML, CNAME, install script, image) and then deploy it using the `peaceiris/actions-gh-pages` action.

Also, update the README to reflect the new, more specific installation URL `https://gmmit.orion.net.ar/install.sh`.

Added new files:
- `site/CNAME`
- `site/index.html`